### PR TITLE
skip annotations when printing error description

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -10,7 +10,7 @@ targetCompatibility = 1.8
 dependencies {
     implementation 'com.iwillfailyou:java-plugin:0.0.3'
     implementation 'org.cactoos:cactoos:0.41'
-    implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.13.6'
+    implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.16.1'
     implementation 'org.apache.httpcomponents:httpclient:4.5.8'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -41,7 +41,7 @@ if (project.rootProject.file('local.properties').exists()) {
         siteUrl = 'https://github.com/iwillfailyou/java-inspections'
         gitUrl = 'https://github.com/iwillfailyou/java-inspections.git'
 
-        libraryVersion = '0.3.2'
+        libraryVersion = '0.3.4'
 
         developerId = 'nikialeksey'
         developerName = 'Alexey Nikitin'

--- a/lib/src/main/java/com/iwillfailyou/javaparser/NodeDescription.java
+++ b/lib/src/main/java/com/iwillfailyou/javaparser/NodeDescription.java
@@ -59,7 +59,7 @@ public final class NodeDescription implements Description {
         description.append(new NodePath(node).asString());
         final Optional<Range> range = node.getChildNodes()
             .stream()
-            .filter(aNode -> !(aNode instanceof MarkerAnnotationExpr))
+            .filter((final Node aNode) -> !(aNode instanceof MarkerAnnotationExpr))
             .findFirst()
             .map(Node::getRange)
             .orElse(node.getRange());
@@ -73,7 +73,7 @@ public final class NodeDescription implements Description {
         description.append(" > ");
         final String causeRepr = cause.value().toString();
         description.append(Arrays.stream(causeRepr.split("\n"))
-            .filter(line -> !line.startsWith("@"))
+            .filter((final String line) -> !line.startsWith("@"))
             .findFirst()
             .orElse(causeRepr));
 

--- a/lib/src/test/java/com/iwillfailyou/javaparser/NodeDescriptionTest.java
+++ b/lib/src/test/java/com/iwillfailyou/javaparser/NodeDescriptionTest.java
@@ -102,7 +102,7 @@ public final class NodeDescriptionTest {
                 "   @Annotation1\n" +
                 "   @Annotation2\n" +
                 "   @Annotation3\n" +
-                "   private static void method() {}\n" +
+                "   private static String a = null;\n" +
                 "}"
         );
         final CompilationUnit unit = result.getResult().get();
@@ -110,14 +110,14 @@ public final class NodeDescriptionTest {
             TypeDeclaration.class
         );
         final TypeDeclaration<?> typeDeclaration = rootOpt.get();
-        final Optional<MethodDeclaration> methodOpt = unit.findFirst(
-            MethodDeclaration.class
+        final Optional<FieldDeclaration> fieldOpt = unit.findFirst(
+            FieldDeclaration.class
         );
-        final MethodDeclaration method = methodOpt.get();
+        final FieldDeclaration field = fieldOpt.get();
 
         Assert.assertThat(
-            new NodeDescription(method, method, typeDeclaration).asString(),
-            IsEqual.equalTo("A.method(A.java:5) > private static void method() {")
+            new NodeDescription(field, field, typeDeclaration).asString(),
+            IsEqual.equalTo("A(A.java:5) > private static String a = null;")
         );
     }
 }


### PR DESCRIPTION
This is a fix for https://github.com/iwillfailyou/service/issues/15 annotation issue.

It's my first time working with javaparser so I am not sure this is the optimal solution.
Looks a little too complicated :) 